### PR TITLE
fix cabofrio order polygons

### DIFF
--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -95,6 +95,9 @@ export default class extends Controller {
           'type': 'fill',
           'source': tileset.sourceValue,
           'source-layer': 'inspections-areas',
+          'layout': {
+            'fill-sort-key': ['coalesce', [ "to-number", ['get', 'sequence']], 0]
+          },
           'paint': {
             'fill-color': ['coalesce', ['get', 'fill'], '#ff7f50'],
             'fill-opacity': [

--- a/lib/tileset-information-and-recipe.json
+++ b/lib/tileset-information-and-recipe.json
@@ -71,6 +71,9 @@
         "source": "mapbox://tileset-source/dedemenezes/arraialdocabo_final_copy",
         "minzoom": 5,
         "maxzoom": 15,
+        "tiles": {
+          "order": "sequence"
+        },
         "features": {
           "attributes": {
             "allowed_output": [
@@ -84,6 +87,7 @@
               "stroke-width",
               "fill-opacity",
               "fill",
+              "sequence",
               "ESCALA",
               "JURISDICAO",
               "ROTULO",


### PR DESCRIPTION
- add attribute to order tiles into recipe
- add ordering into polygon layer using fill-sort-key layout property
