### PR TITLE
update documents album

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+BUCKET_NAME=as_s3_bucket_name
+SECRET_ACCESS_KEY=aws_user_secret_key
+ACCESS_KEY_ID=aws_user_access_key
+GMAIL_ADDRESS=email_to_be_used@gmail.com
+GMAIL_APP_PASSWORD=gmail_app_password
+MAPBOX_API_KEY=mapbox_api_key_starting_with_pk
+MAPBOX_SUPER_KEY=mapbox_api_key_starting_with_sk
+MAPBOX_USERNAME=mapbox_username_not_email
+CLOUDINARY_URL=cloudinary_api_key

--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@
 
 /node_modules
 # Ignore .env file containing credentials.
-.env*
+.env
 # Ignore Mac and Linux file system files
 *.swp
 .DS_Store

--- a/app/controllers/dashboard/albums_controller.rb
+++ b/app/controllers/dashboard/albums_controller.rb
@@ -16,20 +16,20 @@ module Dashboard
       @albums = Album.includes(:gallery).with_documents.with_attached_banner
     end
 
-    def edit_document
-      @album = Album.find(params[:id])
-      @attachments = @album.documents.map do |document_attachment|
-        document_preview_attachment = ActiveStorage::Attachment.joins(:blob)
-                                                               .where(
-                                                                 'active_storage_blobs.filename ILIKE ?',
-                                                                 document_attachment.blob.filename.base
-                                                               ).first
-        {
-          document_attachment:,
-          document_preview_attachment:
-        }
-      end
-    end
+    # def edit_document
+    #   @album = Album.find(params[:id])
+    #   @attachments = @album.documents.map do |document_attachment|
+    #     document_preview_attachment = ActiveStorage::Attachment.joins(:blob)
+    #                                                            .where(
+    #                                                              'active_storage_blobs.filename ILIKE ?',
+    #                                                              document_attachment.blob.filename.base
+    #                                                            ).first
+    #     {
+    #       document_attachment:,
+    #       document_preview_attachment:
+    #     }
+    #   end
+    # end
 
     def new
       @album = Album.new

--- a/app/controllers/dashboard/albums_controller.rb
+++ b/app/controllers/dashboard/albums_controller.rb
@@ -13,9 +13,7 @@ module Dashboard
     end
 
     def documentos
-      @albums = Album.includes(:gallery, :documents_attachments, banner_attachment: :blob).select do |album|
-        album.documents.attached?
-      end
+      @albums = Album.includes(:gallery).with_documents.with_attached_banner
     end
 
     def edit_document

--- a/app/controllers/dashboard/albums_controller.rb
+++ b/app/controllers/dashboard/albums_controller.rb
@@ -9,9 +9,7 @@ module Dashboard
     end
 
     def imagens
-      @albums = Album.includes(:gallery, :documents_attachments, banner_attachment: :blob).select do |album|
-        album.photos.attached?
-      end
+      @albums = Album.includes(:gallery).with_only_photos.with_attached_banner
     end
 
     def documentos

--- a/app/controllers/dashboard/albums_controller.rb
+++ b/app/controllers/dashboard/albums_controller.rb
@@ -18,6 +18,17 @@ module Dashboard
 
     def edit_document
       @album = Album.find(params[:id])
+      @attachments = @album.documents.map do |document_attachment|
+        document_preview_attachment = ActiveStorage::Attachment.joins(:blob)
+                                                               .where(
+                                                                 'active_storage_blobs.filename ILIKE ?',
+                                                                 document_attachment.blob.filename.base
+                                                               ).first
+        {
+          document_attachment:,
+          document_preview_attachment:
+        }
+      end
     end
 
     def new

--- a/app/controllers/dashboard/albums_controller.rb
+++ b/app/controllers/dashboard/albums_controller.rb
@@ -20,6 +20,10 @@ module Dashboard
       end
     end
 
+    def edit_document
+      @album = Album.find(params[:id])
+    end
+
     def new
       @album = Album.new
     end

--- a/app/controllers/dashboard/attachments_controller.rb
+++ b/app/controllers/dashboard/attachments_controller.rb
@@ -1,6 +1,7 @@
 module Dashboard
   class AttachmentsController < ApplicationController
     def destroy
+      raise
       @attachment = ActiveStorage::Attachment.find(params[:id])
       @attachment.purge_later
       purge_document_attachment

--- a/app/controllers/dashboard/attachments_controller.rb
+++ b/app/controllers/dashboard/attachments_controller.rb
@@ -1,20 +1,22 @@
 module Dashboard
   class AttachmentsController < ApplicationController
     def destroy
-      @preview_attachment = ActiveStorage::Attachment.find(params[:id])
-      @preview_attachment.purge_later
-      if params[:document_attachment_id].present?
-        purge_document_attachment
-        redirect_to documentos_dashboard_album_path(@preview_attachment.record), notice: 'Documento removido'
+      @attachment = ActiveStorage::Attachment.find(params[:id])
+      filename = @attachment.blob.filename.base
+      @album = @attachment.record
+      @attachment.purge_later
+      if @album.has_only_photos?
+        redirect_to edit_dashboard_album_path(@album), notice: 'Foto removida'
       else
-        redirect_to imagens_dashboard_albums_path, notice: 'Foto removida'
+        purge_document_attachment(filename)
+        redirect_to edit_dashboard_album_path(@album), notice: 'Documento removido'
       end
     end
 
     private
 
-    def purge_document_attachment
-      document_attachment = ActiveStorage::Attachment.find params[:document_attachment_id]
+    def purge_document_attachment(filename)
+      document_attachment = @album.documents.find { _1.blob.filename.base == filename }
       document_attachment.purge_later
     end
   end

--- a/app/controllers/dashboard/attachments_controller.rb
+++ b/app/controllers/dashboard/attachments_controller.rb
@@ -2,8 +2,8 @@ module Dashboard
   class AttachmentsController < ApplicationController
     def destroy
       @preview_attachment = ActiveStorage::Attachment.find(params[:id])
-      @preview_attachment.purge_later
       if params[:document_attachment_id].present?
+        @preview_attachment.purge_later
         purge_document_attachment
         redirect_to documentos_dashboard_album_path(@preview_attachment.record), notice: 'Documento removido'
       else

--- a/app/controllers/dashboard/attachments_controller.rb
+++ b/app/controllers/dashboard/attachments_controller.rb
@@ -1,27 +1,21 @@
 module Dashboard
   class AttachmentsController < ApplicationController
     def destroy
-      raise
-      @attachment = ActiveStorage::Attachment.find(params[:id])
-      @attachment.purge_later
-      purge_document_attachment
-
-      redirect_to edit_dashboard_album_path(@attachment.record), notice: 'Foto removida'
+      @preview_attachment = ActiveStorage::Attachment.find(params[:id])
+      @preview_attachment.purge_later
+      if params[:document_attachment_id].present?
+        purge_document_attachment
+        redirect_to documentos_dashboard_album_path(@preview_attachment.record), notice: 'Documento removido'
+      else
+        redirect_to imagens_dashboard_albums_path, notice: 'Foto removida'
+      end
     end
 
     private
 
     def purge_document_attachment
-      filename = @attachment.blob.filename.to_s
-
-      return nil unless @attachment.record.is_a?(Album)
-
-      document_from_image = ActiveStorage::Attachment.joins(:blob).find_by("active_storage_blobs.filename LIKE ?",
-                                                                           "#{filename}.pdf")
-
-      return unless document_from_image
-
-      document_from_image.purge_later
+      document_attachment = ActiveStorage::Attachment.find params[:document_attachment_id]
+      document_attachment.purge_later
     end
   end
 end

--- a/app/controllers/dashboard/attachments_controller.rb
+++ b/app/controllers/dashboard/attachments_controller.rb
@@ -2,8 +2,8 @@ module Dashboard
   class AttachmentsController < ApplicationController
     def destroy
       @preview_attachment = ActiveStorage::Attachment.find(params[:id])
+      @preview_attachment.purge_later
       if params[:document_attachment_id].present?
-        @preview_attachment.purge_later
         purge_document_attachment
         redirect_to documentos_dashboard_album_path(@preview_attachment.record), notice: 'Documento removido'
       else

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,6 @@
 module ApplicationHelper
   def rendering_documents_or_images?
-    params[:action] =~ /documentos/ || params[:action] =~ /imagens/
+    params[:action] =~ /document/ || params[:action] =~ /imag/
   end
 
   # SET DASHBOARD HEADER TITLE

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -10,7 +10,6 @@ class Album < ApplicationRecord
   scope :with_documents, -> { joins(:documents_attachments).distinct }
   scope :with_only_photos, -> { left_outer_joins(:documents_attachments).where(documents_attachments: { id: nil }) }
 
-
   def set_banner(attach)
     self.banner = attach.blob
   end
@@ -21,6 +20,10 @@ class Album < ApplicationRecord
                    .push(%w[gallery\ name published updated_at])
                    .flatten
                    .insert(1, 'banner')
+  end
+
+  def has_only_photos?
+    binding.b
   end
 
   def number_of_photos

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -7,6 +7,9 @@ class Album < ApplicationRecord
   has_many :taggings, as: :taggable
   has_many :tags, through: :taggings
   scope :only_published_events, -> { where(is_event: true, published: true) }
+  scope :with_documents, -> { joins(:documents_attachments).distinct }
+  scope :with_only_photos, -> { left_outer_joins(:documents_attachments).where(documents_attachments: { id: nil }) }
+
 
   def set_banner(attach)
     self.banner = attach.blob

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -23,7 +23,7 @@ class Album < ApplicationRecord
   end
 
   def has_only_photos?
-    binding.b
+    documents.empty?
   end
 
   def number_of_photos

--- a/app/policies/album_policy.rb
+++ b/app/policies/album_policy.rb
@@ -10,6 +10,10 @@ class AlbumPolicy < ApplicationPolicy
     user.admin?
   end
 
+  def update?
+    user.admin?
+  end
+
   def show?
     true
   end

--- a/app/policies/dashboard/user_policy.rb
+++ b/app/policies/dashboard/user_policy.rb
@@ -50,5 +50,9 @@ module Dashboard
     def documentos?
       home?
     end
+
+    def edit_document?
+      home?
+    end
   end
 end

--- a/app/policies/gallery_policy.rb
+++ b/app/policies/gallery_policy.rb
@@ -18,6 +18,10 @@ class GalleryPolicy < ApplicationPolicy
     user.admin?
   end
 
+  def update?
+    user.admin?
+  end
+
   def documentos?
     true
   end

--- a/app/views/dashboard/albums/edit.html.erb
+++ b/app/views/dashboard/albums/edit.html.erb
@@ -3,6 +3,7 @@
     <% flash[:alert] = "Selecione uma foto de banner" %>
   <% end %>
   <div class="cards__index mt-3 mb-4">
+    <%= @album.has_only_photos? %>
     <% @album.photos.each do |photo| %>
       <div class="album__card">
         <% if photo.blob.content_type == "image/jpeg" || photo.blob.content_type == "image/png" %>

--- a/app/views/dashboard/albums/edit.html.erb
+++ b/app/views/dashboard/albums/edit.html.erb
@@ -3,17 +3,13 @@
     <% flash[:alert] = "Selecione uma foto de banner" %>
   <% end %>
   <div class="cards__index mt-3 mb-4">
-    <%= @album.has_only_photos? %>
+    <% @album.has_only_photos? %>
     <% @album.photos.each do |photo| %>
       <div class="album__card">
-        <% if photo.blob.content_type == "image/jpeg" || photo.blob.content_type == "image/png" %>
           <%= image_tag "https://rede-observacao-prod.s3.us-east-2.amazonaws.com/#{photo.key}", width: '100%' %>
           <%= link_to dashboard_attachment_path(photo), data: { turbo_method: 'delete', turbo_confirm: 'Essa ação é irreverssível. Voce tem certeza?' }, class: 'album__card__link  card__link--gray' do %>
             <%= icon('fa-solid', 'trash') %>
           <% end %>
-        <% elsif photo.blob.content_type == "application/pdf" %>
-          <%= link_to photo.blob.filename.to_s, photo.url %>
-        <% end %>
       </div>
     <% end %>
   </div>

--- a/app/views/dashboard/albums/edit_document.html.erb
+++ b/app/views/dashboard/albums/edit_document.html.erb
@@ -1,28 +1,27 @@
-mostrar todos os documentos <br>
-opcao para deletar documentos <br>
-opcao para subir novos documentos <br>
-
 <div class="row">
-  <% @album.documents.each do |document| %>
+  <% @attachments.each do |attachment_hash| %>
     <div class="col-3">
-      <% photo = ActiveStorage::Blob.find_by('filename ILIKE ?', "#{document.filename.to_s[...-4]}") %>
       <div class="album__card">
-        <%= link_to "https://rede-observacao-prod.s3.us-east-2.amazonaws.com/#{document.key}",
+        <%= link_to "https://rede-observacao-prod.s3.us-east-2.amazonaws.com/#{attachment_hash[:document_attachment].key}",
                         data: {
-                                pswp_src: "https://rede-observacao-prod.s3.us-east-2.amazonaws.com/#{photo.key}",
-                                pswp_width: photo.metadata[:width],
-                                pswp_height: photo.metadata[:height],
-                                pswp_srcset: "https://rede-observacao-prod.s3.us-east-2.amazonaws.com/#{photo.key}"
+                                pswp_src: "https://rede-observacao-prod.s3.us-east-2.amazonaws.com/#{attachment_hash[:document_preview_attachment].key}",
+                                pswp_width: attachment_hash[:document_preview_attachment].metadata[:width],
+                                pswp_height: attachment_hash[:document_preview_attachment].metadata[:height],
+                                pswp_srcset: "https://rede-observacao-prod.s3.us-east-2.amazonaws.com/#{attachment_hash[:document_preview_attachment].key}"
                               },
                               target: "_blank" do %>
           <div class="card__index text-primary">
-            <div style="background: url('https://rede-observacao-prod.s3.us-east-2.amazonaws.com/<%= photo.key %>');background-size: cover;background-position: top; border-radius: 10px;"></div>
-            <small class="ps-2"><em><%= document.filename %></em></small>
+            <div style="background: url('https://rede-observacao-prod.s3.us-east-2.amazonaws.com/<%= attachment_hash[:document_preview_attachment].key %>');background-size: cover;background-position: top; border-radius: 10px;"></div>
+            <small class="ps-2"><em><%= attachment_hash[:document_attachment].filename %></em></small>
           </div>
         <% end %>
-        <%= photo.inspect %>
-        <%= document.blob.inspect %>
-        <%= link_to dashboard_attachment_path(photo), data: { turbo_method: 'delete', turbo_confirm: 'Essa ação é irreverssível. Voce tem certeza?' }, class: 'album__card__link  card__link--gray' do %>
+        <%= link_to dashboard_attachment_path(
+            attachment_hash[:document_preview_attachment],
+            document_attachment_id: attachment_hash[:document_attachment].id
+          ),
+          data: { turbo_method: 'delete', turbo_confirm: 'Essa ação é irreverssível. Voce tem certeza?' },
+          class: 'album__card__link  card__link--gray' do
+        %>
           <%= icon('fa-solid', 'trash') %>
         <% end %>
       </div>

--- a/app/views/dashboard/albums/edit_document.html.erb
+++ b/app/views/dashboard/albums/edit_document.html.erb
@@ -1,0 +1,32 @@
+mostrar todos os documentos <br>
+opcao para deletar documentos <br>
+opcao para subir novos documentos <br>
+
+<div class="row">
+  <% @album.documents.each do |document| %>
+    <div class="col-3">
+      <% photo = ActiveStorage::Blob.find_by('filename ILIKE ?', "#{document.filename.to_s[...-4]}") %>
+      <div class="album__card">
+        <%= link_to "https://rede-observacao-prod.s3.us-east-2.amazonaws.com/#{document.key}",
+                        data: {
+                                pswp_src: "https://rede-observacao-prod.s3.us-east-2.amazonaws.com/#{photo.key}",
+                                pswp_width: photo.metadata[:width],
+                                pswp_height: photo.metadata[:height],
+                                pswp_srcset: "https://rede-observacao-prod.s3.us-east-2.amazonaws.com/#{photo.key}"
+                              },
+                              target: "_blank" do %>
+          <div class="card__index text-primary">
+            <div style="background: url('https://rede-observacao-prod.s3.us-east-2.amazonaws.com/<%= photo.key %>');background-size: cover;background-position: top; border-radius: 10px;"></div>
+            <small class="ps-2"><em><%= document.filename %></em></small>
+          </div>
+        <% end %>
+        <%= photo.inspect %>
+        <%= document.blob.inspect %>
+        <%= link_to dashboard_attachment_path(photo), data: { turbo_method: 'delete', turbo_confirm: 'Essa ação é irreverssível. Voce tem certeza?' }, class: 'album__card__link  card__link--gray' do %>
+          <%= icon('fa-solid', 'trash') %>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+</div>
+<%= render 'form', album: @album %>

--- a/app/views/dashboard/shared/_content_menu.html.erb
+++ b/app/views/dashboard/shared/_content_menu.html.erb
@@ -1,5 +1,6 @@
 <ul class="list-inline mb-0 mt-2">
   <% %w[index new].each do |action| %>
+  <% next if params[:controller] == "dashboard/albums" && (params[:action] == "edit" || params[:action] == "new") %>
   <% next if skip_new_action_tab?('dashboard/projects', action) || skip_new_action_tab?('dashboard/methodologies', action) %>
     <% active = params[:action] == action %>
     <li class="list-inline-item px-3 py-2 m-0 <%= 'border border-bottom-0 rounded-top tab-shadow' if active %>">

--- a/config/routes/dashboard.rb
+++ b/config/routes/dashboard.rb
@@ -16,7 +16,6 @@ namespace :dashboard do
     end
     member do
       patch 'update_banner'
-      get :edit_document
     end
   end
   delete '/attachments/:id', to: 'attachments#destroy', as: :attachment

--- a/config/routes/dashboard.rb
+++ b/config/routes/dashboard.rb
@@ -16,6 +16,7 @@ namespace :dashboard do
     end
     member do
       patch 'update_banner'
+      get :edit_document
     end
   end
   delete '/attachments/:id', to: 'attachments#destroy', as: :attachment


### PR DESCRIPTION
- WIP - add update action to documents albums
- add env file example for key names
- add scopes to filter album with documents and album with only photos
- refac albums#imagens to use new scope method
- refac albums#documentos to use new scope and avoiding n+1
- update helper method to avoid display dashboard content menu for documents and images on albums
- add edit_document action to display preview images from documents attached
- add preview display to edit documents page
- add destroy action for documents attachments into albums
- add guard clause to remove document attachment
- remove preview before removing document
- WIP - remove edit_document in order to favorite use the regular edit path
- add updte policy to gallery
- add edit for albums (doc and img), displaying attachments preview to remove any attachment. when it has doc, also removes the document attached
- refac content menu to hide navigation for dashboard albums controller
