### PR TITLE
Fix articles controller to accept old params

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -26,7 +26,11 @@ class ArticlesController < ApplicationController
   end
 
   def show
-    @article = Article.find(params[:slug])
+    if params[:slug].match?(/^\d+-./)
+      @article = Article.find(params[:slug])
+    else
+      @article = Article.find_by_header(params[:slug])
+    end
     observatory = @article.observatory
     methodology = @article.methodology
     project = @article.project

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -15,4 +15,11 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "h1", article.header
   end
+
+  test "should show article when url contains only the header (old routing)" do
+    article = articles(:one_featured)
+    get  article_url(article.header)
+    assert_response :success
+    assert_select "h1", article.header
+  end
 end


### PR DESCRIPTION
After updating the article url to become more user friendly, it was not accepting anymore request in the old format. 

This pull request fix it by checking if the param match the new format. It`s a hotfix so it will probably be refactored later. 